### PR TITLE
Replace *all* hyphens - with underscores _ in HTTP headers

### DIFF
--- a/lib/Mojolicious/Plugin/MountPSGI/Proxy.pm
+++ b/lib/Mojolicious/Plugin/MountPSGI/Proxy.pm
@@ -56,7 +56,7 @@ sub _mojo_req_to_psgi_env {
   for my $key (keys %headers) {
     my $value = $headers{$key};
     delete $headers{$key};
-    $key =~ s{-}{_};
+    $key =~ s{-}{_}g;
     $headers{'HTTP_'. uc $key} = $value;
   }
 


### PR DESCRIPTION
From the PSGI spec(1):

```
The key is obtained converting the HTTP header field name to upper
case, replacing all occurrences of hyphens - with underscores _
and prepending HTTP_, as in RFC 3875.
```

For me, the trouble was that HTTP_X_FORWARDED-FOR was set instead of
HTTP_X_FORWARDED_FOR.

1: http://search.cpan.org/~miyagawa/PSGI-1.102/PSGI.pod#SPECIFICATION
